### PR TITLE
Fix UI components for Vercel deploy

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -22,7 +22,7 @@ export async function fetchPrices(symbol: string, range = "5d", interval = "5min
 }
 
 // ---- Stubs para mantener el build estable mientras migrás ----
-export type Rule = { id: string; name: string; active: boolean };
+export type Rule = { id: string; kind: string; enabled: boolean };
 
 // Si ya tenés endpoints reales, reemplazá por fetch a tu backend.
 export async function getRules(): Promise<Rule[]> {
@@ -33,7 +33,13 @@ export async function getSignals(): Promise<any[]> {
   return []; // TODO: reemplazar por fetch(`${BASE}/signals`)
 }
 
-export async function addInstrument(symbol?: string): Promise<{ ok: boolean }> {
+export async function addInstrument(body: {
+  symbol: string;
+  instrument_id: string;
+  type: string;
+  currency: string;
+  source: string;
+}): Promise<{ ok: boolean }> {
   // TODO: reemplazar por POST `${BASE}/instruments`
   return { ok: true };
 }

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,63 +1,21 @@
 import { useEffect, useState } from "react";
-import { fetchPrices } from "@/lib/api";
-import { InstrumentCard } from '@/components/InstrumentCard';
+import { fetchInstruments } from "@/lib/api";
+import { InstrumentCard } from "@/components/InstrumentCard";
 
-const TF = [
-  { label: "1D", range: "1d", interval: "5min" },
-  { label: "5D", range: "5d", interval: "15min" },
-  { label: "1M", range: "1mo", interval: "1hour" },
-  { label: "3M", range: "3mo", interval: "4hour" },
-  { label: "1Y", range: "1y", interval: "1day" },
-];
-
-export function InstrumentCard({ symbol, name }: { symbol: string; name: string }) {
-  const [tf, setTf] = useState(TF[1]); // 5D default
-  const [loading, setLoading] = useState(false);
-  const [data, setData] = useState<Awaited<ReturnType<typeof fetchPrices>> | null>(null);
+export default function Dashboard() {
+  const [instruments, setInstruments] = useState<{ symbol: string; name: string }[]>([]);
+  const [err, setErr] = useState("");
 
   useEffect(() => {
-    let alive = true;
-    setLoading(true);
-    fetchPrices(symbol, tf.range, tf.interval)
-      .then((d) => { if (alive) setData(d); })
-      .finally(() => alive && setLoading(false));
-    return () => { alive = false; };
-  }, [symbol, tf]);
-
-  const series = (data?.series ?? []).map(p => ({ t: p.t, c: p.c }));
-  const last = data?.quote?.last ?? series.at(-1)?.c ?? null;
-  const base = series[0]?.c ?? null;
-  const pct = (last && base) ? ((last - base) / base) * 100 : 0;
-  const isUp = (pct ?? 0) >= 0;
+    fetchInstruments().then(setInstruments).catch(e => setErr(String(e)));
+  }, []);
 
   return (
-    <div className="rounded-2xl border p-3 shadow-sm">
-      <div className="flex items-baseline justify-between">
-        <div>
-          <div className="text-sm text-gray-500">{name}</div>
-          <div className="text-lg font-semibold">{symbol}</div>
-        </div>
-        <div className="text-right">
-          <div className="text-xl font-bold">{last ? last.toFixed(2) : "-"}</div>
-          <div className={isUp ? "text-green-600" : "text-red-600"}>
-            {pct ? `${pct.toFixed(2)}%` : "--"}
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-2">
-        {loading ? <div className="text-sm text-gray-400">Cargando…</div> : <SparklinePercent series={series} />}
-      </div>
-
-      <div className="mt-2 flex gap-2">
-        {TF.map(opt => (
-          <button
-            key={opt.label}
-            onClick={() => setTf(opt)}
-            className={`px-2 py-1 rounded-full text-xs border ${tf.label === opt.label ? "bg-black text-white" : "bg-white"}`}
-          >
-            {opt.label}
-          </button>
+    <div>
+      {err && <div className="text-red-700 text-sm mb-2">{err}</div>}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {instruments.map(inst => (
+          <InstrumentCard key={inst.symbol} symbol={inst.symbol} name={inst.name} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- implement default Dashboard page rendering instrument cards
- adjust API stubs for rules and instrument creation

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9dade6d148324afee8877f9a0d0c1