### PR TITLE
feat: ensure API base URL configuration

### DIFF
--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8000

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,7 +1,7 @@
 # Market Agent UI (MVP)
 
 - React + Vite + Tailwind + Router + Recharts
-- Requiere variable de entorno `VITE_API_URL` apuntando a tu API FastAPI
+- Requiere variable de entorno `VITE_API_BASE` apuntando a tu API FastAPI
 
 ## Scripts
 - `npm run dev` — local dev (http://localhost:5173)
@@ -10,7 +10,9 @@
 
 ## Entorno
 En Vercel, seteá en **Project Settings → Environment Variables**:
-- `VITE_API_URL = https://<tu-servicio-en-render>.onrender.com`
+- `VITE_API_BASE = https://<tu-servicio-en-render>.onrender.com`
+
+Para desarrollo local, copiá `.env.example` a `.env` y ajustá `VITE_API_BASE` si tu API no corre en `http://localhost:8000`.
 
 ## API esperada
 - `GET /healthz` → `{ status: "ok" }`

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,5 +1,11 @@
 // lib/api.ts
-const BASE = import.meta.env.VITE_API_BASE; // Render API
+const BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8000";
+
+if (!import.meta.env.VITE_API_BASE) {
+  console.warn(
+    "VITE_API_BASE no está definido; usando http://localhost:8000 como valor por defecto"
+  );
+}
 
 export async function fetchInstruments() {
   const r = await fetch(`${BASE}/instruments`);


### PR DESCRIPTION
## Summary
- add default http://localhost:8000 for missing VITE_API_BASE and warn developers
- document VITE_API_BASE setup in README and provide .env.example

## Testing
- `pytest`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9df5c3d9c83248477de9796011730